### PR TITLE
Add update default and make version a default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+drush_version: master
+drush_update: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
     repo=https://github.com/drush-ops/drush.git
     dest={{ drush_install_path }}
     version={{ drush_version }}
+    update={{ drush_update }}
 
 - name: Install Drush dependencies with Composer.
   shell: >

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,3 @@
 ---
 drush_install_path: /usr/local/share/drush
 drush_path: /usr/local/bin/drush
-drush_version: master


### PR DESCRIPTION
I think versions and update are better as defaults instead of vars.  The addition of the update variable also allows us to specify whether git should update drush each time - I set the default to no so that its non destructive but I could see the case for the default to be yes as well.
