### PR TITLE
Install Drush plugins

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,6 @@ drush_install_path: /usr/local/share/drush
 drush_path: /usr/local/bin/drush
 drush_version: master
 drush_keep_updated: no
+drush_plugins:
+  - registry_rebuild
+  - drupalgeddon

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: drush clear cache
+  command: "{{ drush_install_path }} cache-clear drush"
+  register: drush_cache_clear
+  changed_when: "'cache was cleared' in drush_cache_clear.stdout"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
   changed_when: "'Execute a drush command' not in drush_result.stdout"
 
 - name: Install Drush plugins.
-  command: "{{ drush_path }} pm-download {{ item }}"
+  command: "{{ drush_path }} pm-download {{ item }} --destination={{ drush_install_path }}/commands"
   args:
-    creates: "~/.drush/{{ item }}"
+    creates: "{{ drush_install_path}}/commands/{{ item }}"
   with_items: drush_plugins

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,3 +36,4 @@
   args:
     creates: "{{ drush_install_path}}/commands/{{ item }}"
   with_items: drush_plugins
+  notify: drush clear cache

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,3 +30,9 @@
   command: "{{ drush_path }}"
   register: drush_result
   changed_when: "'Execute a drush command' not in drush_result.stdout"
+
+- name: Install Drush plugins.
+  command: "{{ drush_path }} pm-download {{ item }}"
+  args:
+    creates: "~/.drush/{{ item }}"
+  with_items: drush_plugins


### PR DESCRIPTION
I've added a `drush_plugins` variable to add plugins such as registry_rebuild and drupalgeddon that are hosted on Drupal.org. These are downloaded into `{{ drush_install_path }}/commands` so that they are available to all users.

The only thing that I'm not 100% sure about it is the "clear drush cache" handler that I've added. I think that it clears it for all users, and I'm not sure if the `changed_when` check is correct. Any thoughts or feedback would be appreciated. :)
