### PR TITLE
Clone depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The version of Drush to install (examples: `master` for the bleeding edge, `7.x`
 
 Whether to keep Drush up-to-date with the latest revision of the branch specified by `drush_version`.
 
+    drush_clone_limit: ~
+
+Whether to clone the entire repo (by default), or specify the number of previous commits for a smaller and faster clone.
+
 ## Dependencies
 
   - geerlingguy.git (Installs Git).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The version of Drush to install (examples: `master` for the bleeding edge, `7.x`
 
 Whether to keep Drush up-to-date with the latest revision of the branch specified by `drush_version`.
 
-    drush_clone_limit: ~
+    drush_clone_depth: ~
 
 Whether to clone the entire repo (by default), or specify the number of previous commits for a smaller and faster clone.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ drush_install_path: /usr/local/share/drush
 drush_path: /usr/local/bin/drush
 drush_version: master
 drush_keep_updated: no
+drush_clone_limit: ~

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,4 @@ drush_install_path: /usr/local/share/drush
 drush_path: /usr/local/bin/drush
 drush_version: master
 drush_keep_updated: no
-drush_clone_limit: ~
+drush_clone_depth: ~

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     dest: "{{ drush_install_path }}"
     version: "{{ drush_version }}"
     update: "{{ drush_keep_updated }}"
-    limit: "{{ drush_clone_limit }}"
+    depth: "{{ drush_clone_depth }}"
 
 # See: https://github.com/geerlingguy/ansible-role-drush/issues/6
 - name: Ensure Drush can be installed on Debian Wheezy.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     dest: "{{ drush_install_path }}"
     version: "{{ drush_version }}"
     update: "{{ drush_keep_updated }}"
+    limit: "{{ drush_clone_limit }}"
 
 # See: https://github.com/geerlingguy/ansible-role-drush/issues/6
 - name: Ensure Drush can be installed on Debian Wheezy.


### PR DESCRIPTION
Allow a user to specify a `--depth` option when cloning the repository from GitHub, for a faster clone.
