### PR TITLE
Force git update when composer.lock is modified.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,19 +16,11 @@
   shell: >
     {{ composer_path }} update {{ drush_composer_cli_options }}
     chdir={{ drush_install_path }}
-    creates={{ drush_install_path }}/vendor/autoload.php
-  when: ansible_distribution == "Debian" and ansible_distribution_release == "wheezy" and drush_composer.stat.exists
+  when: drush_clone.changed and ansible_distribution == "Debian" and ansible_distribution_release == "wheezy" and drush_composer.stat.exists
 
 - name: Install Drush dependencies with Composer.
   shell: >
     {{ composer_path }} install {{ drush_composer_cli_options }}
-    chdir={{ drush_install_path }}
-    creates={{ drush_install_path }}/vendor/autoload.php
-  when: drush_composer.stat.exists
-
-- name: Update Drush dependencies with Composer (if Drush is updated).
-  shell: >
-    {{ composer_path }} update {{ drush_composer_cli_options }}
     chdir={{ drush_install_path }}
   when: drush_clone.changed and drush_composer.stat.exists
 


### PR DESCRIPTION
Another minor issue.

On the 7.x branch when a composer update is run it modifies composer.lock and you get this error ```msg: Local modifications exist in repository (force=no).``` when updating to another version.