### PR TITLE
Keep drush updated by default.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 drush_install_path: /usr/local/share/drush
 drush_path: /usr/local/bin/drush
 drush_version: master
-drush_keep_updated: no
+drush_keep_updated: yes
 
 # These options are the safest for avoiding GitHub API rate limits, but builds
 # can be sped up substantially by changing to --prefer-dist.


### PR DESCRIPTION
If you define a branch as the drush version I would assume you want to stay on the "bleeding edge" otherwise you're stuck on the version of the branch when the task first ran, unless you define ```drush_keep_updated: yes```.

This change won't affect cases where a tag is defined as the version and you can still set ```drush_keep_updated``` to no if for some reason you want to stick to the version of the branch when it was run the first time.

