### PR TITLE
Allow Clone Drush from GitHub task to accept hostkey for github.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ The version of Drush to install (examples: `master` for the bleeding edge, `7.x`
 
     drush_keep_updated: no
     drush_force_update: no
+    
+Add the hostkey for github.com if not already added.
+    
+    drush_accept_hostkey: no
 
 Whether to keep Drush up-to-date with the latest revision of the branch specified by `drush_version`, and whether to force the update (e.g. overwrite local modifications to the drush repository).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ drush_path: /usr/local/bin/drush
 drush_version: master
 drush_keep_updated: no
 drush_force_update: no
+drush_accept_hostkey: no
 
 # These options are the safest for avoiding GitHub API rate limits, but builds
 # can be sped up substantially by changing to --prefer-dist.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
     version: "{{ drush_version }}"
     update: "{{ drush_keep_updated }}"
     force: "{{ drush_force_update }}"
+    accept_hostkey: "{{ drush_accept_hostkey }}"
   register: drush_clone
 
 - name: Check for composer.json


### PR DESCRIPTION
This defaults to `no` so effectively no change to the way the role works however you are able to configure it to accept the hostkey for github.com.