### PR TITLE
Run drush init without privilege escalation.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,3 +35,4 @@
   command: "{{ drush_path }}"
   register: drush_result
   changed_when: "'Execute a drush command' not in drush_result.stdout"
+  become: no


### PR DESCRIPTION
If a playbook is run with privilege escalation, "Run drush to finish setting it up." will create the cache folder at `~/.drush/cache` with incorrect permissions.