### PR TITLE
Drush plugins

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,8 +5,7 @@ drush_version: "master"
 drush_keep_updated: no
 drush_force_update: no
 drush_plugins:
-  - registry_rebuild
-  - drupalgeddon
+  - site_audit
 
 # These options are the safest for avoiding GitHub API rate limits, but builds
 # can be sped up substantially by changing to --prefer-dist.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: drush clear cache
   command: "{{ drush_path }} cache-clear drush"
   register: drush_cache_clear
-  changed_when: "'cache was cleared' in drush_cache_clear.stdout"
+  changed_when: "'cache was cleared' in drush_cache_clear.stderr"
   become: no

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: drush clear cache
-  command: "{{ drush_install_path }} cache-clear drush"
+  command: "{{ drush_path }} cache-clear drush"
   register: drush_cache_clear
   changed_when: "'cache was cleared' in drush_cache_clear.stdout"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
   command: "{{ drush_path }} cache-clear drush"
   register: drush_cache_clear
   changed_when: "'cache was cleared' in drush_cache_clear.stdout"
+  become: no

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: drush clear cache
+- name: drush cache clear drush
   command: "{{ drush_path }} cache-clear drush"
   register: drush_cache_clear
   changed_when: "'cache was cleared' in drush_cache_clear.stderr"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,5 +41,5 @@
   command: "{{ drush_path }} pm-download {{ item }} --destination={{ drush_install_path }}/commands"
   args:
     creates: "{{ drush_install_path}}/commands/{{ item }}"
-  with_items: drush_plugins
+  with_items: "{{ drush_plugins }}"
   notify: drush clear cache

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,4 +42,4 @@
   args:
     creates: "{{ drush_install_path}}/commands/{{ item }}"
   with_items: "{{ drush_plugins }}"
-  notify: drush clear cache
+  notify: drush cache clear drush


### PR DESCRIPTION
This is an updated version of #8.  See the individual commit messages for details.

@opdavies was not sure about the handler that he added.  I tested and
- Either `vagrant` or `root` can clear the drush cache, and it is cleared for all users.
- The message `'drush' cache was cleared` is in stderr, not stdout.

It may be overkill to add a handler for clearing the drush cache.  If we ever use it again, then it is worth it; if not, then we could just add another task.

I do not really like adding the commands to `{{ drush_install_path }}/commands/`, since `drush_install_path` is a git repo, but this seems to be the only site-wide location that is checked by default.  The alternative is a two-step process:  add a system-wide configuration file at `/etc/drush/drushrc.php` and set another path there for the downloaded files.
