### PR TITLE
Adding PECL timezonedb package to fix issue encounted with Drush

### DIFF
--- a/files/timezonedb.ini
+++ b/files/timezonedb.ini
@@ -1,0 +1,1 @@
+extension=timezonedb.so

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+- name: Install PHP Timezone via PECL
+  pear: name=pecl/timezonedb state=present
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_release == "xenial"
+  register: php_timezonedb
+
+- name: Add Timezonedb Config File to PHP CLI
+  copy: src=timezonedb.ini dest=/etc/php/7.0/{{ item }}/conf.d/30-timezonedb.ini owner=root group=root mode=644
+  with_items:
+    - apache2
+    - cli
+    - fpm
+  when: php_timezonedb.changed
+
 - name: Clone Drush from GitHub.
   git:
     repo: https://github.com/drush-ops/drush.git


### PR DESCRIPTION
Adding PECL timezonedb package to fix issue encounted with Drush on Ubuntu Xenial (16.04):

`DateTime::createFromFormat(): Invalid date.timezone value 'UTC', we selected the timezone 'UTC' for now`

Also adding module enable for apache2, cli, and fpm PHP 7 config directories.
---

@geerlingguy Successfully tested on Linode 16.04 base image. Let me know if any of this syntax doesn't match your contribution formatting, and I'll happily change. Also, happy to contribute this to your Galaxy PHP role instead, if you think it's a better fit there, but only encountered this issue specifically using Drush.
