### PR TITLE
Continuing work from #10 - Limit default drush git clone depth to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/geerlingguy/ansible-role-drush.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-drush)
 
-Installs Drush, a command line shell and scripting interface for Drupal, on any Linux or UNIX system.
+Installs [Drush](http://www.drush.org/en/master/), a command line shell and scripting interface for Drupal, on any Linux or UNIX system.
 
 ## Requirements
 
@@ -33,7 +33,7 @@ Whether to keep Drush up-to-date with the latest revision of the branch specifie
 
 These options are the safest for avoiding GitHub API rate limits when installing Drush, and can be very helpful when working on dependencies/installation, but builds can be sped up substantially by changing the first option to --prefer-dist.
 
-    drush_clone_depth: ~
+    drush_clone_depth: 1
 
 Whether to clone the entire repo (by default), or specify the number of previous commits for a smaller and faster clone.
 
@@ -47,7 +47,7 @@ Whether to clone the entire repo (by default), or specify the number of previous
 
     - hosts: servers
       roles:
-        - { role: geerlingguy.drush }
+        - geerlingguy.drush
 
 After the playbook runs, the `drush` command will be accessible from normal system accounts.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Whether to keep Drush up-to-date with the latest revision of the branch specifie
 
 These options are the safest for avoiding GitHub API rate limits when installing Drush, and can be very helpful when working on dependencies/installation, but builds can be sped up substantially by changing the first option to --prefer-dist.
 
+    drush_clone_limit: ~
+
+Whether to clone the entire repo (by default), or specify the number of previous commits for a smaller and faster clone.
+
 ## Dependencies
 
   - geerlingguy.git (Installs Git).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Whether to keep Drush up-to-date with the latest revision of the branch specifie
 
 These options are the safest for avoiding GitHub API rate limits when installing Drush, and can be very helpful when working on dependencies/installation, but builds can be sped up substantially by changing the first option to --prefer-dist.
 
-    drush_clone_limit: ~
+    drush_clone_depth: ~
 
 Whether to clone the entire repo (by default), or specify the number of previous commits for a smaller and faster clone.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,10 @@ drush_install_path: /usr/local/share/drush
 drush_path: /usr/local/bin/drush
 drush_version: "master"
 drush_keep_updated: no
+<<<<<<< HEAD
 drush_force_update: no
 
 drush_composer_cli_options: "--prefer-dist --no-interaction"
+=======
+drush_clone_limit: ~
+>>>>>>> Add drush_clone_limit

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,4 +6,4 @@ drush_keep_updated: no
 drush_force_update: no
 
 drush_composer_cli_options: "--prefer-dist --no-interaction"
-drush_clone_depth: ~
+drush_clone_depth: 1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,10 +3,7 @@ drush_install_path: /usr/local/share/drush
 drush_path: /usr/local/bin/drush
 drush_version: "master"
 drush_keep_updated: no
-<<<<<<< HEAD
 drush_force_update: no
 
 drush_composer_cli_options: "--prefer-dist --no-interaction"
-=======
-drush_clone_limit: ~
->>>>>>> Add drush_clone_limit
+drush_clone_depth: ~

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
     version: "{{ drush_version }}"
     update: "{{ drush_keep_updated }}"
     force: "{{ drush_force_update }}"
-    limit: "{{ drush_clone_limit }}"
+    depth: "{{ drush_clone_depth }}"
   register: drush_clone
 
 - name: Check for composer.json

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
     version: "{{ drush_version }}"
     update: "{{ drush_keep_updated }}"
     force: "{{ drush_force_update }}"
+    limit: "{{ drush_clone_limit }}"
   register: drush_clone
 
 - name: Check for composer.json

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -11,7 +11,7 @@
       when: ansible_os_family == 'RedHat'
 
     - name: Update apt cache.
-      apt: update_cache=yes
+      apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
 
   roles:


### PR DESCRIPTION
See #10, #27.