### PR TITLE
Leverage vagrant-cachier composer caching

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,6 @@
 # See: https://github.com/geerlingguy/ansible-role-drush/issues/6
 - name: Ensure Drush can be installed on Debian Wheezy.
   shell: >
-    COMPOSER_HOME={{ composer_home_path }}
     {{ composer_path }} update {{ drush_composer_cli_options }}
     chdir={{ drush_install_path }}
   when: drush_clone.changed and ansible_distribution == "Debian" and ansible_distribution_release == "wheezy" and drush_composer.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,13 @@
     depth: "{{ drush_clone_depth }}"
   register: drush_clone
 
+- name: Change Drush directory owner.
+  file:
+    path: "{{ drush_install_path }}"
+    owner: "{{ composer_home_owner }}"
+    group: "{{ composer_home_owner }}"
+    recurse: yes
+
 - name: Check for composer.json
   stat: path={{ drush_install_path }}/composer.json
   register: drush_composer
@@ -16,15 +23,18 @@
 # See: https://github.com/geerlingguy/ansible-role-drush/issues/6
 - name: Ensure Drush can be installed on Debian Wheezy.
   shell: >
+    COMPOSER_HOME={{ composer_home_path }}
     {{ composer_path }} update {{ drush_composer_cli_options }}
     chdir={{ drush_install_path }}
   when: drush_clone.changed and ansible_distribution == "Debian" and ansible_distribution_release == "wheezy" and drush_composer.stat.exists
 
 - name: Install Drush dependencies with Composer.
   shell: >
+    COMPOSER_HOME={{ composer_home_path }}
     {{ composer_path }} install {{ drush_composer_cli_options }}
     chdir={{ drush_install_path }}
   when: drush_clone.changed and drush_composer.stat.exists
+  become: no
 
 - name: Create drush symlink.
   file:


### PR DESCRIPTION
### Problem / motivation

The task `Install Drush dependencies with Composer.` runs as `root`, which uses it's own composer cache separate from the standard user's cache.

This cache isn't linked to a `vagrant-cachier` bucket, so on every new VM build composer downloads the Drush dependencies instead of loading them from the cache.

### Suggested fix

Run `composer install` as `composer_home_owner`.

Test results on an Ubuntu 16.04 box:

* All Drush composer dependencies are loaded from cache.
* The task completes 46 seconds faster.

Not sure how this change relates to the the Wheezy task.

#### Rationale

* Composer [warns against running `install` and `update` as `root`](https://getcomposer.org/doc/faqs/how-to-install-untrusted-packages-safely.md).
* Other composer commands using the same home / user can take advantage of the cached dependencies.