### PR TITLE
Drush < 8.1.12 incompatible with 8.4.x

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Install from phar (faster, but less flexible).
-drush_version: "8.1.10"
+drush_version: "8.1.12"
 drush_phar_url: https://github.com/drush-ops/drush/releases/download/{{ drush_version }}/drush.phar
 drush_path: /usr/local/bin/drush
 


### PR DESCRIPTION
Found fix via https://github.com/drud/docker.nginx-php-fpm/commit/ed8a6b8175ac69d90f1faac949991b41bd89746c