### PR TITLE
Drush launcher install for Drush 9 (Drupal 8.4+)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 # Install from phar (faster, but less flexible).
 drush_version: "8.1.10"
-drush_phar_url: https://github.com/drush-ops/drush/releases/download/{{ drush_version }}/drush.phar
+# Install Drush Launcher (Drupal 8.4+).
+drush_launcher_version: "0.3.1"
+drush_phar_url: https://github.com/drush-ops/drush-launcher/releases/download/{{ drush_launcher_version }}/drush.phar
 drush_path: /usr/local/bin/drush
 
 # Install from source (git clone + composer-based install).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: install.yml
-  when: not drush_install_from_source
+  when: not drush_install_from_source or drush_version|version_compare('9.0', '>=')
 
 - include: source-install.yml
-  when: drush_install_from_source
+  when: drush_install_from_source and drush_version|version_compare('9.0', '<')


### PR DESCRIPTION
## Suggested Changes

- Install `drush-ops/drush-launcher` globally, instead of `drush-ops/drush` in line with deprecated global installation method for Drush 9.
- Prevent unsupported global install from source for Drush 9.

## Related Issues

- #41 