### PR TITLE
drush_version isn't used

### DIFF
--- a/tasks/install-drush-composer.yml
+++ b/tasks/install-drush-composer.yml
@@ -1,4 +1,11 @@
 ---
+
+- name: Set Drush version for composer install
+  set_fact:
+    drush_composer_version: "{{ drush_version }}"
+  when:
+    - drush_version is defined
+
 - name: Ensure Drush is installed globally via Composer.
   composer:
     command: require

--- a/tasks/install-source.yml
+++ b/tasks/install-source.yml
@@ -1,4 +1,10 @@
 ---
+- name: Set Drush version for source install
+  set_fact:
+    drush_source_install_version: "{{ drush_version }}"
+  when:
+    - drush_version is defined
+
 - name: Clone Drush from GitHub.
   git:
     repo: https://github.com/drush-ops/drush.git


### PR DESCRIPTION
The Readme says we can use drush_version to set the drush version to use for either composer or source install, but the variable isn't used anywhere. Instead of rewording the Readme, this adds a set_fact to use the combined variable if defined.