### PR TITLE
Fix: Composer expects human input

### DIFF
--- a/tasks/install-drush-composer.yml
+++ b/tasks/install-drush-composer.yml
@@ -1,7 +1,7 @@
 ---
 # Use manual composer tasks until Ansible 2.10.4 is released.
 - name: Ensure Drush is installed globally via Composer.
-  command: "{{ composer_path }} global require drush/drush:{{ drush_composer_version }}"
+  command: "{{ composer_path }} global require drush/drush:{{ drush_composer_version }} {{ drush_composer_cli_options }}" 
   register: drush_composer_require
   changed_when: "'Nothing to install' not in drush_composer_require.stderr"
 


### PR DESCRIPTION
composer stops and waits for human input ... causing the role to time out.
The problem perhaps occurs only if the role is launched with username and password and sudo but I think the fix does not hurt in general for everyone.

